### PR TITLE
fix: 修复对host配置行兼容性问题

### DIFF
--- a/src-tauri/src/commands/hosts_manager.rs
+++ b/src-tauri/src/commands/hosts_manager.rs
@@ -1,8 +1,8 @@
-use std::process::{Command, Stdio};
-use std::{fs, fs::OpenOptions, io::Write};
-
 use crate::state::OSResponse;
 use crate::utils::{to_failure, to_success};
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Stdio};
+use std::{fs, fs::OpenOptions, io::Write};
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
@@ -30,9 +30,29 @@ pub fn write_hosts(file_path: &str, content: &str) -> OSResponse<String> {
 }
 
 #[tauri::command]
+#[cfg(not(unix))]
 pub fn is_file_readonly(file_path: &str) -> OSResponse<bool> {
     match fs::metadata(file_path) {
-        Ok(md) => to_success(md.permissions().readonly()),
+        Ok(md) => {
+            // https://doc.rust-lang.org/std/fs/struct.Permissions.html#unix-including-macos
+            to_success(md.permissions().readonly())
+        }
+        Err(_) => to_failure(format!("Failed to find {}!", file_path)),
+    }
+}
+
+#[tauri::command]
+#[cfg(unix)]
+pub fn is_file_readonly(file_path: &str) -> OSResponse<bool> {
+    match fs::metadata(file_path) {
+        Ok(md) => {
+            // https://doc.rust-lang.org/std/fs/struct.Permissions.html#unix-including-macos
+            let permission = md.permissions();
+            let mode = permission.mode(); // 此处是10进制表示，转二进制吼再取从右往左第八位是当前用户的写权限
+            let is_write = mode & 256 == 256; // 256是2进制8位，取and得是否是1
+
+            to_success(is_write)
+        }
         Err(_) => to_failure(format!("Failed to find {}!", file_path)),
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
-    "devPath": "http://localhost:8000",
+    "devPath": "http://localhost:7001",
     "distDir": "../dist"
   },
   "package": {

--- a/src/models/usePermissionModel.ts
+++ b/src/models/usePermissionModel.ts
@@ -1,5 +1,5 @@
-import { changeHostWritable, isHostFileReadonly } from '@/os';
 import { showPopupInput } from '@/components';
+import { changeHostWritable, isHostFileReadonly } from '@/os';
 import { message } from 'antd';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -17,20 +17,21 @@ function usePermissionModel() {
   }, [checkCanWriteHost]);
 
   const requestPermission = useCallback(async () => {
-    
-      const result = showPopupInput('Please enter your password','password', async (password)=> {
+    const result = showPopupInput(
+      'Please enter your password',
+      'password',
+      async (password) => {
         try {
           await changeHostWritable(password);
           setCanWriteHost(true);
-          result.destroy()  
+          result.destroy();
         } catch (error: any) {
-          console.log(error)
+          console.log(error);
           message.error(error.message, 5);
         }
-        
-      }, null)
-     
-    
+      },
+      null,
+    );
   }, [checkCanWriteHost, setCanWriteHost]);
 
   return {

--- a/src/os.ts
+++ b/src/os.ts
@@ -1,5 +1,6 @@
 import { IHost, IOSResponse } from '@/IType';
 import { invoke } from '@tauri-apps/api';
+import { preprocessEmptySpace } from './utils/string';
 
 const isWindows = process.platform === 'win32';
 
@@ -15,14 +16,14 @@ export async function getOSHosts(): Promise<IHost[]> {
   const response = await invoke<IOSResponse<string>>('read_hosts', {
     filePath: HOSTS,
   });
-  
+
   if (!response.success) {
     throw new Error(response.message);
   }
 
   const lines = response.data.split('\n');
 
-  return lines.map((line) => {
+  return lines.map((line: string) => {
     if (line.startsWith('#') || line === '') {
       return {
         ip: line,
@@ -32,10 +33,13 @@ export async function getOSHosts(): Promise<IHost[]> {
         alias: '',
       };
     }
-    const firstSpaceIndex = line.indexOf(' ');
+
+    const _line = preprocessEmptySpace(line);
+    const firstSpaceIndex = _line.indexOf(' ');
+
     return {
-      ip: line.slice(0, firstSpaceIndex),
-      domain: line.slice(firstSpaceIndex).trim(),
+      ip: _line.slice(0, firstSpaceIndex),
+      domain: _line.slice(firstSpaceIndex).trim(),
       disabled: false,
       invalid: false,
       alias: '',
@@ -58,6 +62,7 @@ async function saveFile(hosts: IHost[]): Promise<IHost[]> {
     content: content,
   });
 
+  debugger;
   if (!response.success) {
     throw new Error(response.message);
   }
@@ -102,7 +107,9 @@ export async function modifyOSHost(
 }
 
 export async function isHostFileReadonly() {
-  const response = await invoke<IOSResponse<boolean>>('is_file_readonly', { filePath: HOSTS });
+  const response = await invoke<IOSResponse<boolean>>('is_file_readonly', {
+    filePath: HOSTS,
+  });
 
   if (!response.success) {
     throw new Error(response.message);

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,4 @@
+export function preprocessEmptySpace(str: string) {
+  const replaced = str.replace(/\s/g, ' ');
+  return replaced.trim();
+}


### PR DESCRIPTION
host行会有tab，把"空"替换成" "再做分割
mac系统下matadata.permission().readonly()并不能查ACL，所以得用PermissionExt [link](https://doc.rust-lang.org/std/fs/struct.Permissions.html#unix-including-macos)